### PR TITLE
Replace `async_setup_platforms` with `async_forward_entry_setups`

### DIFF
--- a/custom_components/electrasmart/__init__.py
+++ b/custom_components/electrasmart/__init__.py
@@ -27,7 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(entry.add_update_listener(update_listener))
     hass.data[DOMAIN][entry.entry_id] = electra_api
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 

--- a/custom_components/electrasmart/manifest.json
+++ b/custom_components/electrasmart/manifest.json
@@ -3,7 +3,7 @@
     "name": "Electra Smart",
     "config_flow": true,
     "documentation": "https://www.home-assistant.io/integrations/electrasmart",
-    "requirements": ["pyelectra==1.0.5"],
+    "requirements": ["pyelectra==1.2.0"],
     "ssdp": [],
     "zeroconf": [],
     "homekit": {},

--- a/custom_components/electrasmart/manifest.json
+++ b/custom_components/electrasmart/manifest.json
@@ -10,5 +10,5 @@
     "dependencies": [],
     "codeowners": ["@jafar-atili"],
     "iot_class": "cloud_polling",
-    "version": "1.2.7"
+    "version": "1.2.8"
 }


### PR DESCRIPTION
Fixes an warning in HomeAssistant 2023.2

```
 [homeassistant.helpers.frame] Detected integration that called async_setup_platforms instead of awaiting async_forward_entry_setups; this will fail in version 2023.3. Please report issue to the custom integration author for electrasmart using this method at custom_components/electrasmart/__init__.py, line 30: hass.config_entries.async_setup_platforms(entry, PLATFORMS)
```